### PR TITLE
Improve game logs display

### DIFF
--- a/cara-client.js
+++ b/cara-client.js
@@ -198,7 +198,10 @@ async function make_game(version,addr,port,sess,cid,script_file,enable_map) {
   }
   //call_code_function("trigger_character_event","cm",{name:data.name,message:JSON.parse(data.message)});
 
-  vm.runInContext("add_log = console.log",game_context);
+  vm.runInContext(
+    `add_log = function(message) {console.log(character ? character.name : "Unknown", '|', message);}`,
+    game_context
+  );
   vm.runInContext("show_json = function(json) {console.log('show_json',json);}",game_context);
   process.send({type: "initialized"});
   process.on("message", (m) => {


### PR DESCRIPTION
Instead of passing the arguments to console.log, try to print the character's name and only print the message without the color code.

Current version:
```
Requested to join Telokill's party gray
```

My suggestion:
```
TeloUrden | Requested to join Telokill's party
```