### PR TITLE
allow requesting shutdown of child runner

### DIFF
--- a/CODE/caracAL/tests/shutdown_test.js
+++ b/CODE/caracAL/tests/shutdown_test.js
@@ -1,0 +1,25 @@
+// This test should be started on your merchant, it will start another non merchant character
+
+console.log(
+  `I am ${character.name} from ${
+    parent.server_region + parent.server_identifier
+  }`
+);
+
+const { deploy, shutdown } = parent.caracAL;
+
+// TODO: start another character, wait a little and request for it to shut down
+const all_chars = parent.X.characters
+  .filter((x) => x.name != character.name)
+  .sort((a, b) => (a.name > b.name ? 1 : -1));
+
+setTimeout(() => {
+  const second_character = all_chars[0];
+  console.log(`deploy ${second_character.name}`)
+  deploy(second_character.name, null);
+
+  setTimeout(() => {
+    console.log(`shutdown ${second_character.name}`)
+    shutdown(second_character.name);
+  }, 5000);
+}, 5000);

--- a/cara-client.js
+++ b/cara-client.js
@@ -159,9 +159,10 @@ async function make_game(version,addr,port,sess,cid,script_file,enable_map) {
       });
     
   }
-  extensions.shutdown = function() {
+  extensions.shutdown = function(char_name) {
     process.send({
-      type: "shutdown"
+      type: "shutdown",
+      character: char_name
     });
   }
   extensions.map_enabled = function() {

--- a/main.js
+++ b/main.js
@@ -234,9 +234,18 @@ function patch_writing(strim) {
           }
           break;
         case "shutdown":
+          
+          if(m.character){
+            const candidate = character_manage[m.character] || {};
+
+            console.log(`shutdown requested for ${m.character} from ${char_name}`)
+            candidate.enabled = false;
+            softkill_block(candidate);
+          } else {
           console.log("shutdown requested from " + char_name)
           char_block.enabled = false;
           softkill_block(char_block);
+          }
           break;
         case "cm":
           let recipients = m.to;


### PR DESCRIPTION
When deploying a second character with `parent.caracAL.deploy(second_character_name, null);` you can also request shutting it down again from the same process that deployed it with `parent.caracAL.shutdown(second_character_name);`

This simulates using iframes in the official client where you run `start_character` and can stop them with `stop_character`